### PR TITLE
Calendar displays actual dates of saved recipes.

### DIFF
--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -64,11 +64,15 @@ class Calendar extends React.Component {
 
   saveMealPlan() {
     let mealPlan = {};
-    mealPlan.recipes = this.state.recipes;
+    let datedRecipes = this.state.recipes.slice();
+    datedRecipes.forEach((recipe, index) => {
+      recipe.date = moment().add(index, 'days').format('ddd L');
+    });
+    mealPlan.recipes = datedRecipes;
     mealPlan.startDate = moment().format('dddd L');
     mealPlan.endDate = moment().add(4, 'days').format('dddd L');
     mealPlan.userId = this.state.userId;
-
+    console.log(mealPlan);
 
     axios.post('/api/mealPlan', mealPlan)
       .then((res) => {
@@ -98,10 +102,6 @@ class Calendar extends React.Component {
       entry.quantity = list[key];
       formattedList.push(entry);
     }
-    //console.log(formattedList)
-    // this.setState({
-    //   list: formattedList
-    // });
     this.props.setList(formattedList);
   }
 
@@ -114,7 +114,10 @@ class Calendar extends React.Component {
           {this.state.recipes.length ? this.state.recipes.map(((recipe, index) => {
             return (
               <Col s={12} m={5} l={2} key={recipe._id}>
-                <Card style={{minWidth: '200px'}} className='large hoverable' header={<div className="calendar-date">{moment().add(index, 'days').format('ddd L')}</div>} >
+                <Card style={{minWidth: '200px'}}
+                  className='large hoverable'
+                  header={<div className={recipe.date === moment().format('ddd L') ? 'calendar-today' : 'calendar-date'}>
+                    {recipe.date ? recipe.date : moment().add(index, 'days').format('ddd L')}</div>} >
                   <MiniRecipe recipe={recipe} key={recipe._id} />
                 </Card>
               </Col>

--- a/client/components/dashboard.js
+++ b/client/components/dashboard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import RecipeEntry from './recipe-entry.js';
 import Bookmarks from './bookmarks.js';
-//import UserStat from './user-stat.js';
-//import FeedMeter from './feed-meter.js';
+import UserStat from './user-stat.js';
+import FeedMeter from './feed-meter.js';
 
 class Dashboard extends React.Component {
   constructor(props) {
@@ -31,12 +31,11 @@ class Dashboard extends React.Component {
         </div>
         <div className="row" align="center">
           <span><strong>Feed Meter!</strong></span>
-          {/* <FeedMeter /> */}
+          <FeedMeter />
         </div>
         <div className="row">
           <div className="col s12 m12 l6">
-            User Stats Here
-            {/* <UserStat /> */}
+            <UserStat />
           </div>
           <div className="col s12 m12 l6">
             <Bookmarks userId={this.state.profile.user_id} />

--- a/client/public/style.css
+++ b/client/public/style.css
@@ -157,6 +157,24 @@ a {
   background-color: #ef9a9a;
 }
 
+.calendar-today {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  color: #000000;
+  background-color: #fbc727;
+}
+
+.calendar-past {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  color: #000000;
+  background-color: lightgrey;
+}
+
 .recipe-mini-title {
   font-weight: bold;
   font-size: 1.3em;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30077025/32082861-77e0ce44-ba8c-11e7-8283-77dcc50b8995.png)

On save, a new meal plan sets a date property on each recipe.
When a saved meal plan renders on the calendar, each entry displays the date it was assigned.
Newly generated plans start from the current date.
The current day's tile displays yellow instead of red.
