### PR TITLE
Added edit functionality to meal calendar.

### DIFF
--- a/client/actions/actions.js
+++ b/client/actions/actions.js
@@ -1,6 +1,8 @@
 export const SET_SHOPPING_LIST = 'SET_SHOPPING_LIST';
 export const SET_USER_INFO = 'SET_USER_INFO';
 export const SET_POINT = 'SET_POINT';
+export const SET_EDIT = 'SET_EDIT';
+
 export const setList = (list) => ({
   type: SET_SHOPPING_LIST,
   payload: list
@@ -14,4 +16,9 @@ export const setUserInfo = (user) => ({
 export const setPoints = (points) => ({
   type: SET_POINT,
   payload: points
+});
+
+export const setEdit = (recipeId) => ({
+  type: SET_EDIT,
+  payload: recipeId
 });

--- a/client/actions/actions.js
+++ b/client/actions/actions.js
@@ -1,4 +1,6 @@
 export const SET_SHOPPING_LIST = 'SET_SHOPPING_LIST';
+export const SET_MEAL_PLAN = 'SET_MEAL_PLAN';
+export const EDIT_MEAL_PLAN = 'EDIT_MEAL_PLAN';
 export const SET_USER_INFO = 'SET_USER_INFO';
 export const SET_POINT = 'SET_POINT';
 export const SET_EDIT = 'SET_EDIT';
@@ -6,6 +8,16 @@ export const SET_EDIT = 'SET_EDIT';
 export const setList = (list) => ({
   type: SET_SHOPPING_LIST,
   payload: list
+});
+
+export const setMealPlan = (mealPlan) => ({
+  type: SET_MEAL_PLAN,
+  payload: mealPlan
+});
+
+export const editMealPlan = (recipeToAdd) => ({
+  type: EDIT_MEAL_PLAN,
+  payload: recipeToAdd
 });
 
 export const setUserInfo = (user) => ({

--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -117,7 +117,8 @@ class Calendar extends React.Component {
           <Col s={0} m={0} l={1} />
         </Row>
         <Button style={{'marginRight': '5px'}} waves='light' className='red lighten-3' onClick={this.saveMealPlan}>Save<Icon left>save</Icon></Button>
-        <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={this.getRandomRecipes}>New Meal Plan<Icon left>cloud</Icon></Button>
+        <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={this.getRandomRecipes}>Auto 5-Day Meal Plan<Icon left>cloud</Icon></Button>
+        <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={console.log('clicked')}>Custom Meal Plan<Icon left>cloud</Icon></Button>
         <div style={{'marginTop': '10px'}}>
           <Link to='/shoppinglist'>
             <Button waves='light' className='red lighten-3'>Weekly Shopping List<Icon left>shopping_cart</Icon></Button>

--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -6,7 +6,7 @@ import ShoppingList from './shopping-list.js';
 import { Card, CardTitle, Row, Col, Button, Icon } from 'react-materialize';
 import { Link, Route } from 'react-router-dom';
 import moment from 'moment';
-import { setList } from '../actions/actions.js';
+import { setList, setMealPlan } from '../actions/actions.js';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
@@ -14,7 +14,6 @@ class Calendar extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      recipes: [],
       list: []
     };
 
@@ -35,9 +34,10 @@ class Calendar extends React.Component {
     })
       .then((response) => {
         if (response.data.recipes) {
-          this.setState({
-            recipes: response.data.recipes
-          });
+          this.props.setMealPlan(response.data.recipes);
+          // this.setState({
+          //   recipes: response.data.recipes
+          // });
           this.makeShoppingList(response.data.recipes);
         }
       });
@@ -47,15 +47,17 @@ class Calendar extends React.Component {
     axios.get('/api/calendarRecipes')
       .then((response) => {
         let listOfFive = response.data.slice(0, 5);
-        this.setState({
-          recipes: listOfFive
-        });
+        this.props.setMealPlan(listOfFive);
+        // this.setState({
+        //   recipes: listOfFive
+        // });
       });
   }
 
   saveMealPlan() {
+    //TODO: fix so if a plan already has dates you don't overwrite them
     let mealPlan = {};
-    let datedRecipes = this.state.recipes.slice();
+    let datedRecipes = this.props.mealPlan.slice();
     datedRecipes.forEach((recipe, index) => {
       recipe.date = moment().add(index, 'days').format('ddd L');
     });
@@ -102,7 +104,7 @@ class Calendar extends React.Component {
         <h5 className="component-title">My Calendar</h5>
         <Row>
           <Col s={0} m={0} l={1} />
-          {this.state.recipes.length ? this.state.recipes.map(((recipe, index) => {
+          {this.props.mealPlan.length ? this.props.mealPlan.map(((recipe, index) => {
             return (
               <Col s={12} m={5} l={2} key={recipe._id}>
                 <Card style={{minWidth: '200px'}}
@@ -134,12 +136,13 @@ class Calendar extends React.Component {
 const mapStateToProps = (state) => {
   return {
     ingredients: state.shoppingList,
+    mealPlan: state.mealPlan,
     user: state.user
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ setList }, dispatch);
+  return bindActionCreators({ setList, setMealPlan }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Calendar);

--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -118,7 +118,7 @@ class Calendar extends React.Component {
         </Row>
         <Button style={{'marginRight': '5px'}} waves='light' className='red lighten-3' onClick={this.saveMealPlan}>Save<Icon left>save</Icon></Button>
         <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={this.getRandomRecipes}>Auto 5-Day Meal Plan<Icon left>cloud</Icon></Button>
-        <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={console.log('clicked')}>Custom Meal Plan<Icon left>cloud</Icon></Button>
+        {/* <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={console.log('clicked')}>Custom Meal Plan<Icon left>cloud</Icon></Button> */}
         <div style={{'marginTop': '10px'}}>
           <Link to='/shoppinglist'>
             <Button waves='light' className='red lighten-3'>Weekly Shopping List<Icon left>shopping_cart</Icon></Button>

--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -24,7 +24,11 @@ class Calendar extends React.Component {
   }
 
   componentDidMount() {
-    this.getPlannedRecipes();
+    if (this.props.mealPlan.length) {
+      this.makeShoppingList(this.props.mealPlan);
+    } else {
+      this.getPlannedRecipes();
+    }
   }
 
   getPlannedRecipes() {
@@ -59,7 +63,9 @@ class Calendar extends React.Component {
     let mealPlan = {};
     let datedRecipes = this.props.mealPlan.slice();
     datedRecipes.forEach((recipe, index) => {
-      recipe.date = moment().add(index, 'days').format('ddd L');
+      if (recipe.date === undefined ) {
+        recipe.date = moment().add(index, 'days').format('ddd L');
+      }
     });
     mealPlan.recipes = datedRecipes;
     mealPlan.startDate = moment().format('dddd L');

--- a/client/components/recipe-details.js
+++ b/client/components/recipe-details.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import { connect } from 'react-redux';
-import { setPoints } from '../actions/actions.js';
+import { setPoints, setMealPlan } from '../actions/actions.js';
 import { bindActionCreators } from 'redux';
 class RecipeDetails extends React.Component {
   constructor(props) {
@@ -241,12 +241,14 @@ class RecipeDetails extends React.Component {
 const mapStateToProps = (state) => {
   return {
     user: state.user,
-    points: state.points
+    points: state.points,
+    mealPlan: state.mealPlan,
+    editId: state.editId
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ setPoints }, dispatch);
+  return bindActionCreators({ setPoints, setMealPlan }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(RecipeDetails);

--- a/client/components/recipe-details.js
+++ b/client/components/recipe-details.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import axios from 'axios';
 import { connect } from 'react-redux';
-import { setPoints, setMealPlan } from '../actions/actions.js';
+import { setPoints, editMealPlan } from '../actions/actions.js';
 import { bindActionCreators } from 'redux';
 class RecipeDetails extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
+      currentRecipe: {},
       name: '',
       imageUrl: '',
       time: 0,
@@ -24,6 +25,7 @@ class RecipeDetails extends React.Component {
     this.handleRemoveBookmark = this.handleRemoveBookmark.bind(this);
     this.checkBookmarks = this.checkBookmarks.bind(this);
     this.handleRecipeComplete = this.handleRecipeComplete.bind(this);
+    this.handleEditPlan = this.handleEditPlan.bind(this);
 
   }
 
@@ -54,6 +56,7 @@ class RecipeDetails extends React.Component {
       .then((res) => {
         const recipe = res.data[0];
         this.setState({
+          currentRecipe: recipe,
           name: recipe.name,
           imageUrl: recipe.imageUrl,
           time: recipe.time,
@@ -121,6 +124,10 @@ class RecipeDetails extends React.Component {
         console.log(err);
       });
     console.log('recipe complete!');
+  }
+
+  handleEditPlan() {
+    this.props.editMealPlan(this.state.currentRecipe);
   }
 
   render() {
@@ -226,6 +233,11 @@ class RecipeDetails extends React.Component {
                           ? <a onClick={this.handleRemoveBookmark} className="btn-floating cyan"><i className="material-icons">bookmark</i></a>
                           : <a onClick={this.handleAddBookmark} className="btn-floating cyan"><i className="material-icons">bookmark_border</i></a>
                       }
+                      {
+                        (this.props.editId)
+                          ? <li><a onClick={this.handleEditPlan} className="btn-floating yellow"><i className="material-icons">bookmark</i></a></li>
+                          : null
+                      }
                     </li>
                   </ul>
                 </div>
@@ -248,7 +260,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ setPoints, setMealPlan }, dispatch);
+  return bindActionCreators({ setPoints, editMealPlan }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(RecipeDetails);

--- a/client/components/recipe-mini.js
+++ b/client/components/recipe-mini.js
@@ -1,5 +1,8 @@
 import React from 'react';
+import { Button, Icon } from 'react-materialize';
 import { Link, Route } from 'react-router-dom';
+import { setEdit } from '../actions/actions.js';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import axios from 'axios';
 
@@ -14,6 +17,7 @@ class MiniRecipe extends React.Component {
     this.checkBookmarks = this.checkBookmarks.bind(this);
     this.handleAddBookmark = this.handleAddBookmark.bind(this);
     this.handleRemoveBookmark = this.handleRemoveBookmark.bind(this);
+    this.handleEdit = this.handleEdit.bind(this);
   }
 
   componentDidMount() {
@@ -24,7 +28,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe.algolia,
+      recipeId: recipe._id,
       userId: userId
     };
 
@@ -43,7 +47,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe.algolia,
+      recipeId: recipe._id,
       userId: userId
     };
     axios.put('/api/bookmarks', params)
@@ -62,7 +66,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe.algolia,
+      recipeId: recipe._id,
       userId: userId
     };
     axios.delete('/api/bookmarks', { params: params })
@@ -77,6 +81,10 @@ class MiniRecipe extends React.Component {
       });
   }
 
+  handleEdit() {
+    this.props.setEdit(this.props.recipe._id);
+  }
+
   render() {
     return (
       <div>
@@ -88,13 +96,27 @@ class MiniRecipe extends React.Component {
         <div>
           <img className="recipe-mini-img" src={(this.props.recipe.imageUrl === 'none') ? '/assets/no_img.jpg' : (this.props.recipe.imageUrl)} />
         </div>
+        {/* button that marks a recipe as complete or not:
+            on click :
+            sets 'completed' key in recipe to 'true'
+              and awards points to user
+              as long as 'completed' is false
+
+            find recipe in current meal plan in redux state
+              make slice of current meal plan
+              set recipe 'completed' to true
+
+             */}
         <div className="card-action">
-          <Link to={`recipes/${this.props.recipe.algolia}`}>Details</Link>
+          <Link to={`recipes/${this.props.recipe._id}`}>Details</Link>
           {
             (this.state.bookmarked)
               ? <a onClick={this.handleRemoveBookmark}>Remove Bookmark</a>
               : <a onClick={this.handleAddBookmark}>Bookmark</a>
           }
+          <div>
+            <a onClick={this.handleEdit}>Edit</a>
+          </div>
         </div>
       </div>
     );
@@ -107,4 +129,8 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(mapStateToProps)(MiniRecipe);
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ setEdit }, dispatch);
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(MiniRecipe);

--- a/client/reducers/mainReducer.js
+++ b/client/reducers/mainReducer.js
@@ -1,7 +1,8 @@
-import { SET_SHOPPING_LIST, SET_USER_INFO, SET_POINT, SET_EDIT } from '../actions/actions.js';
+import { SET_SHOPPING_LIST, SET_MEAL_PLAN, EDIT_MEAL_PLAN, SET_USER_INFO, SET_POINT, SET_EDIT } from '../actions/actions.js';
 const initialState = {
   loggedIn: '',
   shoppingList: [],
+  mealPlan: [],
   user: {},
   points: 0,
   editId: ''
@@ -9,6 +10,8 @@ const initialState = {
 
 export default function(state = initialState, action) {
   let shoppingList;
+  let mealPlan;
+  let recipeToAdd;
   let user;
   let points;
   let editId;
@@ -16,6 +19,19 @@ export default function(state = initialState, action) {
   case SET_SHOPPING_LIST:
     shoppingList = action.payload;
     return {...state, shoppingList };
+  case SET_MEAL_PLAN:
+    mealPlan = action.payload;
+    return {...state, mealPlan};
+  case EDIT_MEAL_PLAN:
+    recipeToAdd = action.payload;
+    mealPlan = state.mealPlan.slice();
+    for (let i = 0; i < editedPlan.length; i ++) {
+      if (mealPlan[i]._id === state.editId) {
+        mealPlan[i] = recipeToAdd;
+        break;
+      }
+    }
+    return {...state, mealPlan};
   case SET_USER_INFO:
     user = action.payload;
     return {...state, user};

--- a/client/reducers/mainReducer.js
+++ b/client/reducers/mainReducer.js
@@ -27,6 +27,7 @@ export default function(state = initialState, action) {
     mealPlan = state.mealPlan.slice();
     for (let i = 0; i < mealPlan.length; i ++) {
       if (mealPlan[i]._id === state.editId) {
+        recipeToAdd.date = mealPlan[i].date;
         mealPlan[i] = recipeToAdd;
         break;
       }

--- a/client/reducers/mainReducer.js
+++ b/client/reducers/mainReducer.js
@@ -1,15 +1,17 @@
-import { SET_SHOPPING_LIST, SET_USER_INFO, SET_POINT } from '../actions/actions.js';
+import { SET_SHOPPING_LIST, SET_USER_INFO, SET_POINT, SET_EDIT } from '../actions/actions.js';
 const initialState = {
   loggedIn: '',
   shoppingList: [],
   user: {},
-  points: 0
+  points: 0,
+  editId: ''
 };
 
 export default function(state = initialState, action) {
   let shoppingList;
   let user;
   let points;
+  let editId;
   switch (action.type) {
   case SET_SHOPPING_LIST:
     shoppingList = action.payload;
@@ -20,6 +22,10 @@ export default function(state = initialState, action) {
   case SET_POINT:
     points = action.payload;
     return {...state, points};
+  case SET_EDIT:
+    console.log('editing');
+    editId = action.payload;
+    return {...state, editId};
   default:
     return state;
   }

--- a/client/reducers/mainReducer.js
+++ b/client/reducers/mainReducer.js
@@ -25,7 +25,7 @@ export default function(state = initialState, action) {
   case EDIT_MEAL_PLAN:
     recipeToAdd = action.payload;
     mealPlan = state.mealPlan.slice();
-    for (let i = 0; i < editedPlan.length; i ++) {
+    for (let i = 0; i < mealPlan.length; i ++) {
       if (mealPlan[i]._id === state.editId) {
         mealPlan[i] = recipeToAdd;
         break;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-materialize": "^1.0.16",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.2.2",
+    "react-widgets": "^4.0.3",
     "redux": "^3.6.0",
     "redux-logger": "^3.0.1",
     "redux-promise-middleware": "^3.2.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30077025/32244829-26809cf6-be50-11e7-9876-7d4569f738ba.png)
Here I've used the edit functions to change every single meal in my list to the same meal.  Confirmed that saving and reloading the correct, edited list work as normal.

Users can now swap out meals one at a time with meals of their choice
Currently the 'swap' button only exists in the recipe-details view

Todo: Give some visual indication of which recipe you've selected to edit
           Add swap buttons to search view and maybe also to calendar view?

     
