### PR TITLE
Improved edit functionality

### DIFF
--- a/client/components/bookmarks.js
+++ b/client/components/bookmarks.js
@@ -39,7 +39,7 @@ export default class Bookmarks extends React.Component {
           <div>
             <ul>
               {(this.state.bookmarks.length)
-                ? this.state.bookmarks.map((recipe) => <li key={recipe._id}><Link to={`recipes/${recipe.algolia}`}>{recipe.name}</Link></li>)
+                ? this.state.bookmarks.map((recipe) => <li key={recipe.algolia}><Link to={`recipes/${recipe.algolia}`}>{recipe.name}</Link></li>)
                 : 'You don\'t have any bookmarked recipes!'}
             </ul>
           </div>

--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -112,12 +112,12 @@ class Calendar extends React.Component {
           <Col s={0} m={0} l={1} />
           {this.props.mealPlan.length ? this.props.mealPlan.map(((recipe, index) => {
             return (
-              <Col s={12} m={5} l={2} key={recipe._id}>
+              <Col s={12} m={5} l={2} key={recipe.algolia}>
                 <Card style={{minWidth: '200px'}}
                   className='large hoverable'
                   header={<div className={recipe.date === moment().format('ddd L') ? 'calendar-today' : 'calendar-date'}>
                     {recipe.date ? recipe.date : moment().add(index, 'days').format('ddd L')}</div>} >
-                  <MiniRecipe recipe={recipe} key={recipe._id} />
+                  <MiniRecipe recipe={recipe} key={recipe.algolia} />
                 </Card>
               </Col>
             );

--- a/client/components/recipe-mini.js
+++ b/client/components/recipe-mini.js
@@ -28,7 +28,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe._id,
+      recipeId: recipe.algolia,
       userId: userId
     };
 
@@ -47,7 +47,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe._id,
+      recipeId: recipe.algolia,
       userId: userId
     };
     axios.put('/api/bookmarks', params)
@@ -66,7 +66,7 @@ class MiniRecipe extends React.Component {
     const userId = this.props.user.user_id;
     const { recipe } = this.props;
     const params = {
-      recipeId: recipe._id,
+      recipeId: recipe.algolia,
       userId: userId
     };
     axios.delete('/api/bookmarks', { params: params })
@@ -82,10 +82,14 @@ class MiniRecipe extends React.Component {
   }
 
   handleEdit() {
-    this.props.setEdit(this.props.recipe._id);
+    let editedRecipe = {};
+    editedRecipe.id = this.props.recipe.algolia;
+    editedRecipe.date = this.props.recipe.date;
+    this.props.setEdit(editedRecipe);
   }
 
   render() {
+    console.log(this.props.recipe);
     return (
       <div>
         <span className="recipe-mini-title">{this.props.recipe.name}</span>
@@ -108,14 +112,18 @@ class MiniRecipe extends React.Component {
 
              */}
         <div className="card-action">
-          <Link to={`recipes/${this.props.recipe._id}`}>Details</Link>
+          <Link to={`recipes/${this.props.recipe.algolia}`}>Details</Link>
           {
             (this.state.bookmarked)
               ? <a onClick={this.handleRemoveBookmark}>Remove Bookmark</a>
               : <a onClick={this.handleAddBookmark}>Bookmark</a>
           }
           <div>
-            <a onClick={this.handleEdit}>Edit</a>
+            {
+              (this.props.editId === this.props.recipe.algolia && this.props.editDate === this.props.recipe.date)
+                ? <a onClick={this.handleEdit}>Editing...</a>
+                : <a onClick={this.handleEdit}>Edit</a>
+            }
           </div>
         </div>
       </div>
@@ -125,7 +133,9 @@ class MiniRecipe extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    user: state.user
+    user: state.user,
+    editId: state.editId,
+    editDate: state.editDate
   };
 };
 

--- a/client/components/recipe-mini.js
+++ b/client/components/recipe-mini.js
@@ -89,7 +89,6 @@ class MiniRecipe extends React.Component {
   }
 
   render() {
-    console.log(this.props.recipe);
     return (
       <div>
         <span className="recipe-mini-title">{this.props.recipe.name}</span>

--- a/client/reducers/mainReducer.js
+++ b/client/reducers/mainReducer.js
@@ -5,7 +5,8 @@ const initialState = {
   mealPlan: [],
   user: {},
   points: 0,
-  editId: ''
+  editId: '',
+  editDate: ''
 };
 
 export default function(state = initialState, action) {
@@ -15,6 +16,7 @@ export default function(state = initialState, action) {
   let user;
   let points;
   let editId;
+  let editDate;
   switch (action.type) {
   case SET_SHOPPING_LIST:
     shoppingList = action.payload;
@@ -26,13 +28,14 @@ export default function(state = initialState, action) {
     recipeToAdd = action.payload;
     mealPlan = state.mealPlan.slice();
     for (let i = 0; i < mealPlan.length; i ++) {
-      if (mealPlan[i]._id === state.editId) {
+      if (mealPlan[i].algolia === state.editId) {
         recipeToAdd.date = mealPlan[i].date;
         mealPlan[i] = recipeToAdd;
         break;
       }
     }
-    return {...state, mealPlan};
+    editId = '';
+    return {...state, mealPlan, editId};
   case SET_USER_INFO:
     user = action.payload;
     return {...state, user};
@@ -40,9 +43,9 @@ export default function(state = initialState, action) {
     points = action.payload;
     return {...state, points};
   case SET_EDIT:
-    console.log('editing');
-    editId = action.payload;
-    return {...state, editId};
+    editId = action.payload.id;
+    editDate = action.payload.date;
+    return {...state, editId, editDate};
   default:
     return state;
   }

--- a/server/request-handler.js
+++ b/server/request-handler.js
@@ -51,37 +51,37 @@ let filterResults = function(arr, bool) {
   }
 };
 
-exports.getsourceUnits = (req, res) => {
-  console.log('Ingridient --> ', req.body);
-  let appid = '6a032b94';
-  let appkey = 'af04dee8c1b92b496501c456b635a697';
-  let url = 'https://api.edamam.com/api/food-database/parser?ingr=' + req.body.food + '&app_id=' + appid + '&app_key=' + appkey + '&page=0';
-  if (req.body.food !== '') {
-    request.get(url, (error, response, body) => {
-      if (error) {
-        console.log('Error --> ', error);
-      }
-      var result = JSON.parse(body);
-      if (result['hints'].length !== 0) {
-        var temp = result['hints'][0]['measures'];
-        let arr = temp.reduce((acc, el) => {
-          acc.push(el.label);
-          return acc;
-        }, []);
-        if (arr.indexOf['Fluid ounce'] !== -1) {
-          arr = filterResults(arr, true);
-        } else {
-          arr = filterResults(arr, false);
-        }
-        res.status(200).send(arr);
-      } else {
-        res.status(200).send('No response');
-      }
-    });
-  } else {
-    res.status(200).send('No input');
-  }
-};
+// exports.getsourceUnits = (req, res) => {
+//   console.log('Ingridient --> ', req.body);
+//   let appid = '6a032b94';
+//   let appkey = 'af04dee8c1b92b496501c456b635a697';
+//   let url = 'https://api.edamam.com/api/food-database/parser?ingr=' + req.body.food + '&app_id=' + appid + '&app_key=' + appkey + '&page=0';
+//   if (req.body.food !== '') {
+//     request.get(url, (error, response, body) => {
+//       if (error) {
+//         console.log('Error --> ', error);
+//       }
+//       var result = JSON.parse(body);
+//       if (result['hints'].length !== 0) {
+//         var temp = result['hints'][0]['measures'];
+//         let arr = temp.reduce((acc, el) => {
+//           acc.push(el.label);
+//           return acc;
+//         }, []);
+//         if (arr.indexOf['Fluid ounce'] !== -1) {
+//           arr = filterResults(arr, true);
+//         } else {
+//           arr = filterResults(arr, false);
+//         }
+//         res.status(200).send(arr);
+//       } else {
+//         res.status(200).send('No response');
+//       }
+//     });
+//   } else {
+//     res.status(200).send('No input');
+//   }
+// };
 
 
 exports.sendRecipes = (req, res) => {
@@ -101,7 +101,7 @@ exports.sendRecipes = (req, res) => {
 
 exports.getRecipeDetail = (req, res) => {
   const { recipeId } = req.params;
-
+  console.log(req);
   Recipe.find({'algolia': recipeId}).exec()
     .then((recipe) => {
       res.status(200).send(recipe);

--- a/server/server.js
+++ b/server/server.js
@@ -34,7 +34,7 @@ app.get('/api/recipes', handler.sendRecipes);
 app.post('/api/recipes', foodUpload, handler.newRecipe);
 
 // meal plan handlers
-app.post('/api/units', handler.getsourceUnits);
+//app.post('/api/units', handler.getsourceUnits);
 app.get('/api/calendarRecipes', handler.getCalendarRecipes);
 app.get('/api/mealPlan', handler.sendMealPlan);
 app.post('/api/mealPlan', handler.saveMealPlan);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30077025/32252266-073a4610-be6b-11e7-84e4-795d2ed8f373.png)

Edit button now changes for the recipe being edited
Now saving edited recipe date to state as well to account for possible duplicate recipes in list
Recipe details 'replace' button only shows up when editing is happening and disappears as soon as the current edited recipe is replaced.

Commented out unused 'edamame' api calls in request handler b/c it was causing weird errors

Todo: 
Add replace button to search view
Redirect to search view when 'edit' is pressed