### PR TITLE
Shopping List link in Calendar disabled while shopping list is building.

### DIFF
--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -168,9 +168,10 @@ class Calendar extends React.Component {
         <Button style={{'marginRight': '5px'}} waves='light' className='red lighten-3' onClick={this.saveMealPlan}>Save<Icon left>save</Icon></Button>
         <Button style={{'marginLeft': '5px'}} waves='light' className='red lighten-3' onClick={this.getRandomRecipes}>Auto 5-Day Meal Plan<Icon left>cloud</Icon></Button>
         <div style={{'marginTop': '10px'}}>
-          <Link to='/shoppinglist'>
-            <Button waves='light' className='red lighten-3'>Weekly Shopping List<Icon left>shopping_cart</Icon></Button>
-          </Link>
+          { this.props.ingredients.length
+            ? <Link to='/shoppinglist'><Button waves='light' className='red lighten-3'>Weekly Shopping List<Icon left>shopping_cart</Icon></Button></Link>
+            : <Button waves='light' className='disabled red lighten-3'>Preparing Your Shopping List...<Icon left>shopping_cart</Icon></Button>
+          }
         </div>
       </div>
     );

--- a/client/utils/ingredientParsers.js
+++ b/client/utils/ingredientParsers.js
@@ -57,4 +57,5 @@ const unitMerger = (unitList) => {
   return units.join(', ');
 };
 
+
 export default unitMerger;


### PR DESCRIPTION
Button should stay disabled and not link to shopping list component until state.shoppingList is a non-empty array.  Should prevent the occasional empty-shopping-list bug we've been running into.