### PR TITLE
Added parens removal for ingredient names, alphabetical list sorting.

### DIFF
--- a/client/components/calendar.js
+++ b/client/components/calendar.js
@@ -9,7 +9,7 @@ import moment from 'moment';
 import { setList, setMealPlan } from '../actions/actions.js';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import unitMerger, { commaRemover } from '../utils/ingredientParsers.js';
+import unitMerger, { commaRemover, parensRemover } from '../utils/ingredientParsers.js';
 
 class Calendar extends React.Component {
   constructor(props) {
@@ -80,8 +80,8 @@ class Calendar extends React.Component {
     let formattedList = [];
     recipes.forEach((recipe) => {
       recipe.ingredients.forEach((ingredient) => {
-        console.log(ingredient.name);
-        let shortName = commaRemover(ingredient.name);
+        let nameSansParens = parensRemover(ingredient.name);
+        let shortName = commaRemover(nameSansParens);
         let splitIngredient = ingredient.quantity.split(' ');
         let units = splitIngredient[splitIngredient.length - 1].toLowerCase();
         if (units === 'cup' || units === 'tablespoon' || units === 'teaspoon' || units === 'stick') {
@@ -145,6 +145,13 @@ class Calendar extends React.Component {
       entry.quantity = unitMerger(quantity);
       formattedList.push(entry);
     }
+    formattedList.sort((a, b) => {
+      if (a.name > b.name) {
+        return 1;
+      } else {
+        return -1;
+      }
+    });
     this.props.setList(formattedList);
   }
 

--- a/client/utils/ingredientParsers.js
+++ b/client/utils/ingredientParsers.js
@@ -64,5 +64,22 @@ export const commaRemover = (ingredientTitle) => {
   return ingredientTitle;
 };
 
+export const parensRemover = (ingredientTitle) => {
+  if (ingredientTitle.includes('(')) {
+    let openIndex = ingredientTitle.indexOf('(');
+    let closeIndex = ingredientTitle.indexOf(')');
+    let subset = ingredientTitle.substring(openIndex + 1, closeIndex);
+    let splitSet = subset.split(' ');
+    if (Number(splitSet[0])) {
+      return ingredientTitle;
+    } else {
+      let parsedStart = ingredientTitle.substring(0, openIndex);
+      let parsedEnd = ingredientTitle.substring(closeIndex + 1);
+      return parsedStart + parsedEnd;
+    }
+  }
+  return ingredientTitle;
+};
+
 
 export default unitMerger;


### PR DESCRIPTION
Removes contents of blocks in parens from titles if those blocks don't have useful quantity info in them (i.e. 'Celery (diced)' becomes 'Celery' but '(1 pound) chicken breasts' stays the same).

Sorts shopping list alphabetically (looks more organized but maybe there's a more useful sort we could use?  Will revisit that if we have time)